### PR TITLE
Features/feedback planner

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,11 @@ on:
     push:
         branches:
             - main
+        paths:
+            - 'vanilla_aiagents/**'
     pull_request:
+        paths:
+            - 'vanilla_aiagents/**'      
     workflow_dispatch:
 
 jobs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,11 @@
 {
-    "python.terminal.activateEnvironment": true
+    "python.terminal.activateEnvironment": true,
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true,
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true,
+            "source.unusedImports": "always"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
   <h3 align="center">Vanilla AI Agents</h3>
 
-  <a href="https://github.com/azure-samples/vanilla-aiagents/main/LICENSE.md"><img src="https://img.shields.io/github/license/Azure-Samples/vanilla-aiagents" alt="License" /></a>
-  <a href="https://github.com/Azure-Samples/vanilla-aiagents/actions/workflows/pytest.yml"><img src="https://github.com/Azure-Samples/vanilla-aiagents/actions/workflows/pytest.yml/badge.svg" alt="Test status" /></a>
-  <a href="https://github.com/Azure-Samples/vanilla-aiagents/releases"><img src="https://img.shields.io/github/v/release/Azure-Samples/vanilla-aiagents" alt="Releases" /></a>
-  <a href="https://Azure-Samples.github.io/vanilla-aiagents/"><img src="https://img.shields.io/badge/GitHub%20Pages-Online-success" alt="GitHub Pages" /></a>
+<a href="https://github.com/azure-samples/vanilla-aiagents/main/LICENSE.md"><img src="https://img.shields.io/github/license/Azure-Samples/vanilla-aiagents" alt="License" /></a>
+<a href="https://github.com/Azure-Samples/vanilla-aiagents/actions/workflows/pytest.yml"><img src="https://github.com/Azure-Samples/vanilla-aiagents/actions/workflows/pytest.yml/badge.svg" alt="Test status" /></a>
+<a href="https://github.com/Azure-Samples/vanilla-aiagents/releases"><img src="https://img.shields.io/github/v/release/Azure-Samples/vanilla-aiagents" alt="Releases" /></a>
+<a href="https://Azure-Samples.github.io/vanilla-aiagents/"><img src="https://img.shields.io/badge/GitHub%20Pages-Online-success" alt="GitHub Pages" /></a>
+<a href="https://semver.org/"><img src="https://img.shields.io/badge/semver-2.0.0-blue" alt="Semver 2.0.0" /></a>
 
   <p>Lightweight library demonstrating how to create agenting application without using any specific framework.</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@
 
 This project framework provides the following features:
 
-- Multi-agent chat
-- Agent routing (including option to look for available tools to decide)
+- Multi-agent chat with several orchestration options
+  - Dynamic routing (including option to look for available tools to decide)
+  - Beforehand planning with optional repetition via feedback loop
 - Agent state management
 - Custom stop conditions
 - Interactive or unattended user input

--- a/notebooks/planned_team.ipynb
+++ b/notebooks/planned_team.ipynb
@@ -116,8 +116,7 @@
     "from vanilla_aiagents.conversation import SummarizeMessagesStrategy\n",
     "flow = PlannedTeam(id=\"flow\", description=\"\", \n",
     "        members=[collector, approver, responder], \n",
-    "        llm=llm, \n",
-    "        stop_callback=lambda msgs: len(msgs) > 6, \n",
+    "        llm=llm,\n",
     "        fork_conversation=True,\n",
     "        fork_strategy=SummarizeMessagesStrategy(llm, \"Summarize the conversation, provide a list of key information, decisions taken and eventual outcomes.\"))\n",
     "workflow = Workflow(askable=flow)"

--- a/notebooks/planned_team_feedback.ipynb
+++ b/notebooks/planned_team_feedback.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Planned Team\n",
+    "# Planned Team with feeback loop\n",
     "\n",
-    "Unlike other `Team` examples, where the `Agent` selection is performed at ever round of the conversation, this one does not follow a provided structure, nor it lets agents to play against each other. Instead, it will initially define a plan based on the available agents and initial inquiry, to then follow it sequentially."
+    "Like `planned_team.ipynb`, but with a feedback callback to repeat planning and execution until certain criteria are met. The idea is to instruct an `Agent` to be always last in the plan and fill in some variables with the feedback from the previous execution, if any. When `repeat_until` callback is invoked, it checks those variables and decides whether to repeat the planning and execution or not. `PlannedTeam` will then be able to plan and execute according to the given feedback."
    ]
   },
   {
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -105,7 +105,7 @@
     }
    ],
    "source": [
-    "# Telling the agents to set context variables implies calling a pre-defined function call\n",
+    "# A sales agent that provides offers to users\n",
     "sales = Agent(\n",
     "    id=\"sales\",\n",
     "    llm=llm,\n",
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +133,7 @@
    ],
    "source": [
     "\n",
-    "# Second agent will have its system message extended automatically with the context from the ongoing conversation\n",
+    "# A catalog agent that provides prices and discounts for products\n",
     "catalog = Agent(\n",
     "    id=\"catalog\",\n",
     "    llm=llm,\n",
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -169,7 +169,10 @@
     }
    ],
    "source": [
-    "\n",
+    "# A buyer agent that provides feedback on offers\n",
+    "# Key points: \n",
+    "# - it is specified to call this last and to never accept the first offer, so at least one more execution must be done\n",
+    "# - agent instructions indicated which variables to set when accepting or rejecting the offer\n",
     "buyer = Agent(\n",
     "    id=\"buyer\",\n",
     "    llm=llm,\n",
@@ -187,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +204,8 @@
     }
    ],
    "source": [
-    "\n",
+    "# Callback logic, check the aforementioned variables to determine if the conversation can end\n",
+    "# Also, limit the conversation to 10 messages to avoid potentially infinite loops\n",
     "def can_end(conversation: Conversation) -> bool:\n",
     "    return conversation.variables.get(\"result\") == \"done\" or len(conversation.messages) > 10\n",
     "\n",
@@ -209,8 +213,11 @@
     "    id=\"offer\",\n",
     "    description=\"\",\n",
     "    members=[sales, catalog, buyer],\n",
+    "    # We use the reasoning_llm to provide the instructions to the agents, not required but useful\n",
     "    llm=reasoning_llm,\n",
+    "    # Not mandatory, but useful to improve planning in general\n",
     "    include_tools_descriptions=True,\n",
+    "    # Callback specified here\n",
     "    repeat_until=can_end,\n",
     ")\n",
     "workflow = Workflow(askable=flow)"

--- a/notebooks/planned_team_feedback.ipynb
+++ b/notebooks/planned_team_feedback.ipynb
@@ -1,0 +1,437 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Planned Team\n",
+    "\n",
+    "Unlike other `Team` examples, where the `Agent` selection is performed at ever round of the conversation, this one does not follow a provided structure, nor it lets agents to play against each other. Instead, it will initially define a plan based on the available agents and initial inquiry, to then follow it sequentially."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add the parent directory to sys.path\n",
+    "import sys, os\n",
+    "sys.path.append(os.path.abspath(os.path.join('../vanilla_aiagents')))\n",
+    "\n",
+    "from vanilla_aiagents.agent import Agent\n",
+    "from vanilla_aiagents.llm import AzureOpenAILLM, LLMConstraints\n",
+    "from vanilla_aiagents.workflow import Workflow\n",
+    "from vanilla_aiagents.planned_team import PlannedTeam\n",
+    "from vanilla_aiagents.conversation import Conversation\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:azure.identity._credentials.environment:No environment configuration found.\n",
+      "INFO:azure.identity._credentials.managed_identity:ManagedIdentityCredential will use IMDS\n",
+      "INFO:azure.identity._credentials.managed_identity:ManagedIdentityCredential will use IMDS\n",
+      "INFO:azure.identity._credentials.environment:No environment configuration found.\n",
+      "INFO:azure.identity._credentials.managed_identity:ManagedIdentityCredential will use IMDS\n"
+     ]
+    }
+   ],
+   "source": [
+    "llm = AzureOpenAILLM({\n",
+    "    \"azure_deployment\": \"gpt-4o\",\n",
+    "    \"azure_endpoint\": os.getenv(\"AZURE_OPENAI_ENDPOINT\"),\n",
+    "    \"api_key\": os.getenv(\"AZURE_OPENAI_KEY\"),\n",
+    "    \"api_version\": os.getenv(\"AZURE_OPENAI_API_VERSION\"),\n",
+    "})\n",
+    "reasoning_llm = AzureOpenAILLM({\n",
+    "    \"azure_deployment\": \"o1-mini\",\n",
+    "    \"azure_endpoint\": os.getenv(\"AZURE_OPENAI_ENDPOINT\"),\n",
+    "    \"api_key\": os.getenv(\"AZURE_OPENAI_KEY\"),\n",
+    "    \"api_version\": os.getenv(\"AZURE_OPENAI_API_VERSION\"),\n",
+    "}, constraints=LLMConstraints(temperature=1, structured_output=False, system_message=False))\n",
+    "\n",
+    "# Set logging to debug for Agent, User and Workflow\n",
+    "import logging\n",
+    "\n",
+    "# Set logging to debug for Agent, User, and Workflow\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "logging.getLogger(\"vanilla_aiagents.agent\").setLevel(logging.DEBUG)\n",
+    "logging.getLogger(\"vanilla_aiagents.planned_team\").setLevel(logging.DEBUG)\n",
+    "logging.getLogger(\"vanilla_aiagents.user\").setLevel(logging.DEBUG)\n",
+    "logging.getLogger(\"vanilla_aiagents.workflow\").setLevel(logging.DEBUG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:vanilla_aiagents.agent:Agent initialized with ID: sales, Description: Sales agent, takes price and discounts to provide an offer. Use a professional tone\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Telling the agents to set context variables implies calling a pre-defined function call\n",
+    "sales = Agent(\n",
+    "    id=\"sales\",\n",
+    "    llm=llm,\n",
+    "    description=\"Sales agent, takes price and discounts to provide an offer. Use a professional tone\",\n",
+    "    system_message=\"\"\"You are part of an AI sales process\n",
+    "Your task is to respond to the user buying ask by providing a price and a discount.\n",
+    "You're goal is to maximize sold value, so keep discount low unless the user keeps asking for it.\n",
+    "NEVER exceed the maximum discount for the product.\n",
+    "\"\"\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:vanilla_aiagents.agent:Agent initialized with ID: catalog, Description: Product catalog agent, provides prices and discounts\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# Second agent will have its system message extended automatically with the context from the ongoing conversation\n",
+    "catalog = Agent(\n",
+    "    id=\"catalog\",\n",
+    "    llm=llm,\n",
+    "    description=\"Product catalog agent, provides prices and discounts\",\n",
+    "    system_message=\"\"\"You are part of an AI process\n",
+    "Your task is to provide price and discount information for the sales agent to use in the offer.\n",
+    "\n",
+    "# PRODUCTS PRICES AND DISCOUNTS\n",
+    "- Oven: $1000\n",
+    "    - MAX Discount: 25%\n",
+    "- Fridge: $1500\n",
+    "    - MAX Discount: 10%\n",
+    "- Washing machine: $800\n",
+    "    - MAX Discount: 15%\n",
+    "    \n",
+    "Use the following JSON format to provide the information:\n",
+    "{{\"product\": \"name\", \"price\": \"1000\", \"max_discount\": 0.10}}\n",
+    "\"\"\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:vanilla_aiagents.agent:Agent initialized with ID: buyer, Description: Buyer agent, will provide feedback on the offer. MUST be called last in the workflow\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "buyer = Agent(\n",
+    "    id=\"buyer\",\n",
+    "    llm=llm,\n",
+    "    description=\"Buyer agent, will provide feedback on the offer. MUST be called last in the workflow\",\n",
+    "    system_message=\"\"\"You are part of an AI sales process.\n",
+    "    Your task is to provide feedback on the offer provided by the sales agent.\n",
+    "    Never accept the first offer\n",
+    "    Minimum acceptable discount is 10%.\n",
+    "    \n",
+    "    When offer can be accepted, set variable \"result\" to \"done\"\n",
+    "    When offer is not acceptable, set variable \"result\" to \"KO\" and \"__feedback\" to \"I want a better discount\"\n",
+    "    \"\"\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] initialized with agents: {'sales': <vanilla_aiagents.agent.Agent object at 0x000001D9E87063D0>, 'catalog': <vanilla_aiagents.agent.Agent object at 0x000001D9E86BA2D0>, 'buyer': <vanilla_aiagents.agent.Agent object at 0x000001D9E853ECD0>}\n",
+      "DEBUG:vanilla_aiagents.workflow:Workflow initialized\n",
+      "DEBUG:vanilla_aiagents.workflow:Workflow initialized\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "def can_end(conversation: Conversation) -> bool:\n",
+    "    return conversation.variables.get(\"result\") == \"done\" or len(conversation.messages) > 10\n",
+    "\n",
+    "flow = PlannedTeam(\n",
+    "    id=\"offer\",\n",
+    "    description=\"\",\n",
+    "    members=[sales, catalog, buyer],\n",
+    "    llm=reasoning_llm,\n",
+    "    include_tools_descriptions=True,\n",
+    "    repeat_until=can_end,\n",
+    ")\n",
+    "workflow = Workflow(askable=flow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:vanilla_aiagents.workflow:Conversation length: 0\n",
+      "DEBUG:vanilla_aiagents.workflow:Restarted workflow, cleared conversation.\n",
+      "DEBUG:vanilla_aiagents.workflow:Running workflow with input: I want a new oven\n",
+      "DEBUG:vanilla_aiagents.workflow:Conversation length: 0\n",
+      "DEBUG:vanilla_aiagents.workflow:Added system prompt to messages: \n",
+      "DEBUG:vanilla_aiagents.workflow:Added user input to messages: I want a new oven\n",
+      "INFO:azure.core.pipeline.policies.http_logging_policy:Request URL: 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=REDACTED&resource=REDACTED'\n",
+      "Request method: 'GET'\n",
+      "Request headers:\n",
+      "    'User-Agent': 'azsdk-python-identity/1.19.0 Python/3.11.11 (Windows-10-10.0.26100-SP0)'\n",
+      "No body was attached to the request\n",
+      "INFO:azure.identity._credentials.chained:DefaultAzureCredential acquired a token from AzureCliCredential\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/o1-mini/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] result from Azure OpenAI: ChatCompletionMessage(content='```json\\n{\\n    \"plan\": [\\n        {\\n            \"agent_id\": \"catalog\",\\n            \"instructions\": \"Provide prices and available discounts for ovens.\"\\n        },\\n        {\\n            \"agent_id\": \"sales\",\\n            \"instructions\": \"Use the provided prices and discounts to create a professional offer for the new oven.\"\\n        },\\n        {\\n            \"agent_id\": \"buyer\",\\n            \"instructions\": \"Provide feedback on the offer for the new oven.\"\\n        }\\n    ]\\n}\\n```', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] created plan: [TeamPlanStep(agent_id='catalog', instructions='Provide prices and available discounts for ovens.'), TeamPlanStep(agent_id='sales', instructions='Use the provided prices and discounts to create a professional offer for the new oven.'), TeamPlanStep(agent_id='buyer', instructions='Provide feedback on the offer for the new oven.')]\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: catalog\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Local messages prepared for API call (last 3): [{'role': 'system', 'content': 'You are part of an AI process\\nYour task is to provide price and discount information for the sales agent to use in the offer.\\n\\n# PRODUCTS PRICES AND DISCOUNTS\\n- Oven: $1000\\n    - MAX Discount: 25%\\n- Fridge: $1500\\n    - MAX Discount: 10%\\n- Washing machine: $800\\n    - MAX Discount: 15%\\n    \\nUse the following JSON format to provide the information:\\n{{\"product\": \"name\", \"price\": \"1000\", \"max_discount\": 0.10}}\\n'}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}]\n",
+      "INFO:azure.core.pipeline.policies.http_logging_policy:Request URL: 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=REDACTED&resource=REDACTED'\n",
+      "Request method: 'GET'\n",
+      "Request headers:\n",
+      "    'User-Agent': 'azsdk-python-identity/1.19.0 Python/3.11.11 (Windows-10-10.0.26100-SP0)'\n",
+      "No body was attached to the request\n",
+      "INFO:azure.identity._credentials.chained:DefaultAzureCredential acquired a token from AzureCliCredential\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] API response received: ChatCompletionMessage(content='Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Response message: {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: sales\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Local messages prepared for API call (last 3): [{'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}]\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] API response received: ChatCompletionMessage(content=\"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Response message: {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: buyer\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Local messages prepared for API call (last 3): [{'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}]\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] API response received: ChatCompletionMessage(content='I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Response message: {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: catalog\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}, {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Local messages prepared for API call (last 3): [{'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}, {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}]\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] API response received: ChatCompletionMessage(content='Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: catalog] Response message: {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: sales\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}, {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Local messages prepared for API call (last 3): [{'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}]\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] API response received: ChatCompletionMessage(content=\"I understand you're looking for a better discount. To accommodate your request, I can offer you a 15% discount. This brings the price of the oven down to $850. Let me know if this works for you!\", refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: sales] Response message: {'content': \"I understand you're looking for a better discount. To accommodate your request, I can offer you a 15% discount. This brings the price of the oven down to $850. Let me know if this works for you!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] current agent: buyer\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Received messages: [{'role': 'system', 'content': ''}, {'role': 'user', 'name': 'user', 'content': 'I want a new oven'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}, {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide prices and available discounts for ovens.'}, {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```', 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'catalog'}, {'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"I understand you're looking for a better discount. To accommodate your request, I can offer you a 15% discount. This brings the price of the oven down to $850. Let me know if this works for you!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}]\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Local messages prepared for API call (last 3): [{'role': 'assistant', 'name': 'offer', 'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'}, {'content': \"I understand you're looking for a better discount. To accommodate your request, I can offer you a 15% discount. This brings the price of the oven down to $850. Let me know if this works for you!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'sales'}, {'role': 'assistant', 'name': 'offer', 'content': 'Provide feedback on the offer for the new oven.'}]\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://ricchi-oai-sw.openai.azure.com//openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview \"HTTP/1.1 200 OK\"\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] API response received: ChatCompletionMessage(content=\"The offer is acceptable, and the process is marked as complete. Let me know if there's anything else you'd like!\", refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)\n",
+      "DEBUG:vanilla_aiagents.agent:[Agent ID: buyer] Response message: {'content': \"The offer is acceptable, and the process is marked as complete. Let me know if there's anything else you'd like!\", 'refusal': None, 'role': 'assistant', 'audio': None, 'function_call': None, 'tool_calls': None, 'name': 'buyer'}\n",
+      "DEBUG:vanilla_aiagents.planned_team:[PlannedTeam offer] asked current agent with messages: done\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'done'"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "workflow.restart()\n",
+    "\n",
+    "workflow.run(\"I want a new oven\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[TeamPlanStep(agent_id='catalog', instructions='Provide prices and available discounts for ovens.'),\n",
+       " TeamPlanStep(agent_id='sales', instructions='Use the provided prices and discounts to create a professional offer for the new oven.'),\n",
+       " TeamPlanStep(agent_id='buyer', instructions='Provide feedback on the offer for the new oven.')]"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flow.plan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'role': 'system', 'content': ''},\n",
+       " {'role': 'user', 'name': 'user', 'content': 'I want a new oven'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Provide prices and available discounts for ovens.'},\n",
+       " {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```',\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'catalog'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'},\n",
+       " {'content': \"The price of a new oven is $1,000. I can offer you a 10% discount, bringing the price down to $900. Let me know if you're ready to proceed or if you'd like to discuss further!\",\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'sales'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Provide feedback on the offer for the new oven.'},\n",
+       " {'content': 'I have provided feedback on the offer: \"I want a better discount.\" Let me know if there\\'s anything else you\\'d like to adjust.',\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'buyer'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Provide prices and available discounts for ovens.'},\n",
+       " {'content': 'Here is the price and discount information for an oven:\\n\\n```json\\n{\\n  \"product\": \"oven\",\\n  \"price\": \"1000\",\\n  \"max_discount\": 0.25\\n}\\n```',\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'catalog'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Use the provided prices and discounts to create a professional offer for the new oven.'},\n",
+       " {'content': \"I understand you're looking for a better discount. To accommodate your request, I can offer you a 15% discount. This brings the price of the oven down to $850. Let me know if this works for you!\",\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'sales'},\n",
+       " {'role': 'assistant',\n",
+       "  'name': 'offer',\n",
+       "  'content': 'Provide feedback on the offer for the new oven.'},\n",
+       " {'content': \"The offer is acceptable, and the process is marked as complete. Let me know if there's anything else you'd like!\",\n",
+       "  'refusal': None,\n",
+       "  'role': 'assistant',\n",
+       "  'audio': None,\n",
+       "  'function_call': None,\n",
+       "  'tool_calls': None,\n",
+       "  'name': 'buyer'}]"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "workflow.conversation.messages"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".conda",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/vanilla_aiagents/tests/test_llm.py
+++ b/vanilla_aiagents/tests/test_llm.py
@@ -1,27 +1,33 @@
 import unittest
 import os, logging, sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from pydantic import BaseModel
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from vanilla_aiagents.workflow import Workflow
 from vanilla_aiagents.agent import Agent
 from vanilla_aiagents.sequence import Sequence
-from vanilla_aiagents.llm import AzureOpenAILLM
+from vanilla_aiagents.llm import AzureOpenAILLM, LLMConstraints
 from vanilla_aiagents.team import Team
 
 from dotenv import load_dotenv
+
 load_dotenv(override=True)
+
 
 class TestLLM(unittest.TestCase):
 
     def setUp(self):
-        self.llm = AzureOpenAILLM({
-            "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
-            "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
-            "api_key": os.getenv("AZURE_OPENAI_KEY"),
-            "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
-        })
-        
+        self.llm = AzureOpenAILLM(
+            {
+                "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
+                "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_key": os.getenv("AZURE_OPENAI_KEY"),
+                "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
+            }
+        )
+
         # Set logging to debug for Agent, User, and Workflow
         logging.basicConfig(level=logging.INFO)
         # logging.getLogger("vanilla_aiagents.agent").setLevel(logging.DEBUG)
@@ -30,60 +36,140 @@ class TestLLM(unittest.TestCase):
 
     def test_metrics_sequence(self):
         # Telling the agents to set context variables implies calling a pre-defined function call
-        first = Agent(id="first", llm=self.llm, description="First agent", system_message = """You are part of an AI process
+        first = Agent(
+            id="first",
+            llm=self.llm,
+            description="First agent",
+            system_message="""You are part of an AI process
         Your task is to set a context for the next agent to continue the conversation.
 
         DO set context variable "CHANNEL" to "voice" and "LANGUAGE" to "en"
 
         DO respond only "Context set" when you are done.
-        """)
+        """,
+        )
 
         # Second agent might have its system message extended automatically with the context from the ongoing conversation
-        second = Agent(id="second", llm=self.llm, description="Second agent", system_message = """You are part of an AI process
+        second = Agent(
+            id="second",
+            llm=self.llm,
+            description="Second agent",
+            system_message="""You are part of an AI process
         Your task is to continue the conversation based on the context set by the previous agent.
         When asked, you can use variable provide in CONTEXT to generate the response.
 
         --- CONTEXT ---
         __context__
-        """)
-        
+        """,
+        )
+
         flow = Sequence(id="flow", description="", steps=[first, second], llm=self.llm)
         workflow = Workflow(askable=flow)
-        
+
         workflow.run("Which channel is this conversation on?")
-        
-        self.assertGreater(workflow.conversation.metrics.completion_tokens, 0, "Expected completion_tokens to be greater than 0")
-        self.assertGreater(workflow.conversation.metrics.prompt_tokens, 0, "Expected prompt_tokens to be greater than 0")
-        self.assertGreater(workflow.conversation.metrics.total_tokens, 0, "Expected total_tokens to be greater than 0")   
-            
+
+        self.assertGreater(
+            workflow.conversation.metrics.completion_tokens,
+            0,
+            "Expected completion_tokens to be greater than 0",
+        )
+        self.assertGreater(
+            workflow.conversation.metrics.prompt_tokens,
+            0,
+            "Expected prompt_tokens to be greater than 0",
+        )
+        self.assertGreater(
+            workflow.conversation.metrics.total_tokens,
+            0,
+            "Expected total_tokens to be greater than 0",
+        )
+
     def test_metrics_team(self):
         # Telling the agents to set context variables implies calling a pre-defined function call
-        first = Agent(id="first", llm=self.llm, description="First agent", system_message = """You are part of an AI process
+        first = Agent(
+            id="first",
+            llm=self.llm,
+            description="First agent",
+            system_message="""You are part of an AI process
         Your task is to set a context for the next agent to continue the conversation.
 
         DO set context variable "CHANNEL" to "voice" and "LANGUAGE" to "en"
 
         DO respond only "Context set" when you are done.
-        """)
+        """,
+        )
 
         # Second agent might have its system message extended automatically with the context from the ongoing conversation
-        second = Agent(id="second", llm=self.llm, description="Second agent", system_message = """You are part of an AI process
+        second = Agent(
+            id="second",
+            llm=self.llm,
+            description="Second agent",
+            system_message="""You are part of an AI process
         Your task is to continue the conversation based on the context set by the previous agent.
         When asked, you can use variable provide in CONTEXT to generate the response.
 
         --- CONTEXT ---
         __context__
-        """)
-        
-        flow = Team(id="flow", description="", members=[first, second], llm=self.llm, stop_callback=lambda x: len(x) > 2)
+        """,
+        )
+
+        flow = Team(
+            id="flow",
+            description="",
+            members=[first, second],
+            llm=self.llm,
+            stop_callback=lambda x: len(x) > 2,
+        )
         workflow = Workflow(askable=flow)
-        
+
         workflow.run("Which channel is this conversation on?")
-        
-        self.assertGreater(workflow.conversation.metrics.completion_tokens, 0, "Expected completion_tokens to be greater than 0")
-        self.assertGreater(workflow.conversation.metrics.prompt_tokens, 0, "Expected prompt_tokens to be greater than 0")
-        self.assertGreater(workflow.conversation.metrics.total_tokens, 0, "Expected total_tokens to be greater than 0")       
+
+        self.assertGreater(
+            workflow.conversation.metrics.completion_tokens,
+            0,
+            "Expected completion_tokens to be greater than 0",
+        )
+        self.assertGreater(
+            workflow.conversation.metrics.prompt_tokens,
+            0,
+            "Expected prompt_tokens to be greater than 0",
+        )
+        self.assertGreater(
+            workflow.conversation.metrics.total_tokens,
+            0,
+            "Expected total_tokens to be greater than 0",
+        )
+
+    def test_constraints(self):
+        llm2 = AzureOpenAILLM(
+            {
+                "azure_deployment": "o1-mini",
+                "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_key": os.getenv("AZURE_OPENAI_KEY"),
+                "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
+            },
+            constraints=LLMConstraints(
+                temperature=1, structured_output=False, system_message=False
+            ),
+        )
+
+        class HelloResponse(BaseModel):
+            response: str
+
+        response, metrics = llm2.ask(
+            messages=[
+                {
+                    "role": "system",
+                    "content": """Say hello with JSON format {response: "message"}""",
+                }
+            ],
+            response_format=HelloResponse,
+            temperature=0.7,
+        )
+
+        # If this call passes, then the constraints are working
+        self.assertIsNotNone(response, "Expected response to be not None")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/vanilla_aiagents/tests/test_planned_team.py
+++ b/vanilla_aiagents/tests/test_planned_team.py
@@ -2,34 +2,42 @@ from typing import Annotated
 import unittest
 import os, logging, sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from vanilla_aiagents.workflow import Workflow
-from vanilla_aiagents.conversation import SummarizeMessagesStrategy
+from vanilla_aiagents.conversation import Conversation, SummarizeMessagesStrategy
 from vanilla_aiagents.agent import Agent
 from vanilla_aiagents.planned_team import PlannedTeam
 from vanilla_aiagents.llm import AzureOpenAILLM
 
 from dotenv import load_dotenv
+
 load_dotenv(override=True)
+
 
 class TestPlannedTeam(unittest.TestCase):
 
     def setUp(self):
-        self.llm = AzureOpenAILLM({
-            "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
-            "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
-            "api_key": os.getenv("AZURE_OPENAI_KEY"),
-            "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
-        })
-        
+        self.llm = AzureOpenAILLM(
+            {
+                "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
+                "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_key": os.getenv("AZURE_OPENAI_KEY"),
+                "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
+            }
+        )
+
         # Set logging to debug for Agent, User, and Workflow
         logging.basicConfig(level=logging.INFO)
         logging.getLogger("vanilla_aiagents.agent").setLevel(logging.DEBUG)
         logging.getLogger("vanilla_aiagents.planned_team").setLevel(logging.DEBUG)
 
     def test_fork(self):
-        collector = Agent(id="datacollector", llm=self.llm, description="Call this agent to collect data for an insurance claim", system_message = """You are part of an AI process
+        collector = Agent(
+            id="datacollector",
+            llm=self.llm,
+            description="Call this agent to collect data for an insurance claim",
+            system_message="""You are part of an AI process
         Your task is to collect key information for an insurance claim to be processed.
         You need to collect the following information:
         - Policy number
@@ -47,10 +55,14 @@ class TestPlannedTeam(unittest.TestCase):
             "incident_kind": "car accident",
             "reimbursement_amount": 1000
         }
-        """)
+        """,
+        )
 
-        
-        approver = Agent(id="approver", llm=self.llm, description="Call this agent to approve the claim", system_message = """You are part of an AI process
+        approver = Agent(
+            id="approver",
+            llm=self.llm,
+            description="Call this agent to approve the claim",
+            system_message="""You are part of an AI process
         Your task is to review the information collected for an insurance claim.
         Approval is subject to the following criteria:
         - If the description refers to a car accident
@@ -59,68 +71,204 @@ class TestPlannedTeam(unittest.TestCase):
         - If the description refers to a house fire
             - approve the claim if the reimbursement amount is less than 5000 USD
             - reject the claim if the reimbursement amount is 5000 USD or more
-        """)
-        
-        responder = Agent(id="responder", llm=self.llm, description="Call this agent to respond to the claim", system_message = """You are part of an AI process
+        """,
+        )
+
+        responder = Agent(
+            id="responder",
+            llm=self.llm,
+            description="Call this agent to respond to the claim",
+            system_message="""You are part of an AI process
         Your task is to respond to the claimant based on the approval decision.
         If the claim is approved, respond with "Your claim has been approved".
         If the claim is rejected, respond with "Your claim has been rejected". Provide a reason for the rejection.
-        """)
-        
-        flow = PlannedTeam(id="flow", description="", 
-                           members=[collector, approver, responder], 
-                           llm=self.llm, 
-                           stop_callback=lambda msgs: len(msgs) > 6, 
-                           fork_conversation=True,
-                           fork_strategy=SummarizeMessagesStrategy(self.llm, "Summarize the conversation, focusing on the key points and decisions made."))
+        """,
+        )
+
+        flow = PlannedTeam(
+            id="flow",
+            description="",
+            members=[collector, approver, responder],
+            llm=self.llm,
+            fork_conversation=True,
+            fork_strategy=SummarizeMessagesStrategy(
+                self.llm,
+                "Summarize the conversation, focusing on the key points and decisions made.",
+            ),
+        )
         workflow = Workflow(askable=flow)
         workflow.restart()
-        
+
         workflow.run(ticket)
-        
-        self.assertEqual(len(workflow.conversation.messages), 3, "Expected 3 messages (sys+user+planned) in the original conversation")
+
+        self.assertEqual(
+            len(workflow.conversation.messages),
+            3,
+            "Expected 3 messages (sys+user+planned) in the original conversation",
+        )
         # Expect last message to be a dict with name and content keys
-        self.assertIn("name", workflow.conversation.messages[-1], "Expected last message to have a 'name' key")
-        self.assertIn("content", workflow.conversation.messages[-1], "Expected last message to have a 'content' key")
-        self.assertEqual(workflow.conversation.messages[-1]["name"], "summarizer", "Expected last message to be from the summarizer")
-        
+        self.assertIn(
+            "name",
+            workflow.conversation.messages[-1],
+            "Expected last message to have a 'name' key",
+        )
+        self.assertIn(
+            "content",
+            workflow.conversation.messages[-1],
+            "Expected last message to have a 'content' key",
+        )
+        self.assertEqual(
+            workflow.conversation.messages[-1]["name"],
+            "summarizer",
+            "Expected last message to be from the summarizer",
+        )
+
     def test_include_tools(self):
         # Telling the agents to set context variables implies calling a pre-defined function call
-        first = Agent(id="first", llm=self.llm, description="First agent", system_message = """You are part of an AI process
+        first = Agent(
+            id="first",
+            llm=self.llm,
+            description="First agent",
+            system_message="""You are part of an AI process
         Your task is to support the user inquiry by providing the user profile.
         Use a tool to retrieve the user profile.
-        """)
-        
-        @first.register_tool(name="get_user_profile", description="Get the user profile")
-        def get_user_profile() -> Annotated[str, "User profile in JSON format"]:
-            return "{\"name\": \"John\", \"age\": 30}"
+        """,
+        )
 
-        # Second agent might have its system message extended automatically with the context from the ongoing conversation
-        second = Agent(id="second", llm=self.llm, description="Second agent", system_message = """You are part of an AI process
+        @first.register_tool(
+            name="get_user_profile", description="Get the user profile"
+        )
+        def get_user_profile() -> (
+            Annotated[str, "User profile in JSON format, with name and age"]
+        ):
+            return '{"name": "John", "age": 30}'
+
+        # Second agent will have its system message extended automatically with the context from the ongoing conversation
+        second = Agent(
+            id="second",
+            llm=self.llm,
+            description="Second agent",
+            system_message="""You are part of an AI process
         Your task is to support the user inquiry.
-        When the users asks if they are eligible for a discount, use a tool to check the user profile.
-        
-        When done, include "DONE" in your response.
-        """)
-        
-        @second.register_tool(name="check_discount_eligibility", description="Check if the user is eligible for a discount")
-        def check_discount_eligibility(age: Annotated[int, "The user age"]) -> Annotated[str, "Eligibility message"]:
-            return "You are eligible for a discount" if age < 25 else "You are not eligible for a discount"
-        
-        flow = PlannedTeam(id="flow", description="", members=[first, second], llm=self.llm, include_tools_descriptions=True, stop_callback=lambda x: "DONE" in x[-1]["content"])
+        When the users asks if they are eligible for a discount, use a tool to check discount eligibility.
+        """,
+        )
+
+        @second.register_tool(
+            name="check_discount_eligibility",
+            description="Check if the user is eligible for a discount",
+        )
+        def check_discount_eligibility(
+            age: Annotated[int, "The user age"]
+        ) -> Annotated[str, "Eligibility message"]:
+            return (
+                "You are eligible for a discount"
+                if age < 25
+                else "You are not eligible for a discount"
+            )
+
+        flow = PlannedTeam(
+            id="flow",
+            description="",
+            members=[first, second],
+            llm=self.llm,
+            include_tools_descriptions=True,
+        )
         workflow = Workflow(askable=flow)
         workflow.restart()
-        
+
         result = workflow.run("Can I have a discount?")
-        
-        self.assertEqual(result, "callback-stop", "Expected the workflow result to be 'done'")
-        self.assertEqual(workflow.conversation.messages[-1]["name"], second.id, "Expected second agent to respond with DONE")
-        self.assertIn("not eligible", workflow.conversation.messages[-1]["content"], "Expected result to be 'not eligible'")
-        
-        # self.assertIn("voice", workflow.conversation.messages[3]["content"], "Expected second agent to recognize context variable CHANNEL")
+
+        self.assertEqual(result, "done", "Expected the workflow result to be 'done'")
+        self.assertEqual(
+            workflow.conversation.messages[-1]["name"],
+            second.id,
+            "Expected second agent to respond with DONE",
+        )
+        self.assertIn(
+            "not eligible",
+            workflow.conversation.messages[-1]["content"],
+            "Expected result to be 'not eligible'",
+        )
+
+    def test_feedback(self):
+        sales = Agent(
+            id="sales",
+            llm=self.llm,
+            description="Sales agent, takes price and discounts to provide an offer. Use a professional tone",
+            system_message="""You are part of an AI sales process
+        Your task is to respond to the user buying ask by providing a price and a discount.
+        You're goal is to maximize sold value, so keep discount low unless the user keeps asking for it.
+        NEVER exceed the maximum discount for the product.
+        """,
+        )
+
+        catalog = Agent(
+            id="catalog",
+            llm=self.llm,
+            description="Product catalog agent, provides prices and discounts",
+            system_message="""You are part of an AI process
+        Your task is to provide price and discount information for the sales agent to use in the offer.
+
+        # PRODUCTS PRICES AND DISCOUNTS
+        - Oven: $1000
+            - MAX Discount: 25%
+        - Fridge: $1500
+            - MAX Discount: 10%
+        - Washing machine: $800
+            - MAX Discount: 15%
+            
+        Use the following JSON format to provide the information:
+        {{"product": "name", "price": "1000", "max_discount": 0.10}}
+        """,
+        )
+
+        buyer = Agent(
+            id="buyer",
+            llm=self.llm,
+            description="Buyer agent, will provide feedback on the offer. MUST be called last in the workflow",
+            system_message="""You are part of an AI sales process.
+            Your task is to provide feedback on the offer provided by the sales agent.
+            Never accept the first offer
+            Minimum acceptable discount is 10%.
+            
+            When offer can be accepted, set variable "result" to "done"
+            When offer is not acceptable, set variable "result" to "KO" and "__feedback" to "I want a better discount"
+            """,
+        )
+
+        def can_end(conversation: Conversation) -> bool:
+            return (
+                conversation.variables.get("result") == "done"
+                or len(conversation.messages) > 10
+            )
+
+        flow = PlannedTeam(
+            id="offer",
+            description="",
+            members=[sales, catalog, buyer],
+            llm=self.llm,
+            include_tools_descriptions=True,
+            repeat_until=can_end,
+        )
+        workflow = Workflow(askable=flow)
+        workflow.restart()
+
+        result = workflow.run("I want a new oven")
+
+        self.assertEqual(result, "done", "Expected the workflow result to be 'done'")
+        self.assertIn(
+            "acceptable",
+            workflow.conversation.messages[-1]["content"],
+            "Expected result to be 'acceptable'",
+        )
 
     def test_plan(self):
-        collector = Agent(id="datacollector", llm=self.llm, description="Call this agent to collect data for an insurance claim", system_message = """You are part of an AI process
+        collector = Agent(
+            id="datacollector",
+            llm=self.llm,
+            description="Call this agent to collect data for an insurance claim",
+            system_message="""You are part of an AI process
         Your task is to collect key information for an insurance claim to be processed.
         You need to collect the following information:
         - Policy number
@@ -138,10 +286,14 @@ class TestPlannedTeam(unittest.TestCase):
             "incident_kind": "car accident",
             "reimbursement_amount": 1000
         }
-        """)
+        """,
+        )
 
-        
-        approver = Agent(id="approver", llm=self.llm, description="Call this agent to approve the claim", system_message = """You are part of an AI process
+        approver = Agent(
+            id="approver",
+            llm=self.llm,
+            description="Call this agent to approve the claim",
+            system_message="""You are part of an AI process
         Your task is to review the information collected for an insurance claim.
         Approval is subject to the following criteria:
         - If the description refers to a car accident
@@ -150,20 +302,31 @@ class TestPlannedTeam(unittest.TestCase):
         - If the description refers to a house fire
             - approve the claim if the reimbursement amount is less than 5000 USD
             - reject the claim if the reimbursement amount is 5000 USD or more
-        """)
-        
-        responder = Agent(id="responder", llm=self.llm, description="Call this agent to respond to the claim", system_message = """You are part of an AI process
+        """,
+        )
+
+        responder = Agent(
+            id="responder",
+            llm=self.llm,
+            description="Call this agent to respond to the claim",
+            system_message="""You are part of an AI process
         Your task is to respond to the claimant based on the approval decision.
         If the claim is approved, respond with "Your claim has been approved".
         If the claim is rejected, respond with "Your claim has been rejected". Provide a reason for the rejection.
-        """)
-        
-        flow = PlannedTeam(id="flow", description="", members=[collector, approver, responder], llm=self.llm, stop_callback=lambda msgs: len(msgs) > 6)
+        """,
+        )
+
+        flow = PlannedTeam(
+            id="flow",
+            description="",
+            members=[collector, approver, responder],
+            llm=self.llm,
+        )
         workflow = Workflow(askable=flow)
         workflow.restart()
-        
+
         workflow.run(ticket)
-        
+
         # Should be as follows:
         # 0. system message from the workflow
         # 1. user input
@@ -173,19 +336,52 @@ class TestPlannedTeam(unittest.TestCase):
         # 5. approver response
         # 6. responder input
         # 7. responder response
-        self.assertEqual(len(workflow.conversation.messages), 8, "Expected 8 messages in the conversation")
-        
-        self.assertEqual(workflow.conversation.messages[3]["name"], "datacollector", "Expected data collector to respond first")
-        self.assertIn("car accident", workflow.conversation.messages[3]["content"].lower(), "Expected data collector to respond with incident description for car accident")
-        self.assertIn("1000", workflow.conversation.messages[3]["content"], "Expected data collector to respond with reimbursement amount of 1000")
-        
-        self.assertEqual(workflow.conversation.messages[5]["name"], "approver", "Expected approver to respond second")
-        self.assertIn("reject", workflow.conversation.messages[5]["content"], "Expected approver to reject the claim")
-        
-        self.assertEqual(workflow.conversation.messages[7]["name"], "responder", "Expected responder to respond last")
-        self.assertIn("rejected", workflow.conversation.messages[7]["content"], "Expected responder to respond with claim rejection message")
+        self.assertEqual(
+            len(workflow.conversation.messages),
+            8,
+            "Expected 8 messages in the conversation",
+        )
 
-ticket= """
+        self.assertEqual(
+            workflow.conversation.messages[3]["name"],
+            "datacollector",
+            "Expected data collector to respond first",
+        )
+        self.assertIn(
+            "car accident",
+            workflow.conversation.messages[3]["content"].lower(),
+            "Expected data collector to respond with incident description for car accident",
+        )
+        self.assertIn(
+            "1000",
+            workflow.conversation.messages[3]["content"],
+            "Expected data collector to respond with reimbursement amount of 1000",
+        )
+
+        self.assertEqual(
+            workflow.conversation.messages[5]["name"],
+            "approver",
+            "Expected approver to respond second",
+        )
+        self.assertIn(
+            "reject",
+            workflow.conversation.messages[5]["content"],
+            "Expected approver to reject the claim",
+        )
+
+        self.assertEqual(
+            workflow.conversation.messages[7]["name"],
+            "responder",
+            "Expected responder to respond last",
+        )
+        self.assertIn(
+            "rejected",
+            workflow.conversation.messages[7]["content"],
+            "Expected responder to respond with claim rejection message",
+        )
+
+
+ticket = """
 From: Alice Thompson <a_thompson@foo.com>
 To: Contoso Insurance Team <report@contoso-insurancec.com>
 Subject: URGENT: Car Accident Claim - Immediate Assistance Required
@@ -217,5 +413,5 @@ Warm regards,
 Alice Thompson
 """
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/vanilla_aiagents/tests/test_planned_team.py
+++ b/vanilla_aiagents/tests/test_planned_team.py
@@ -240,7 +240,7 @@ class TestPlannedTeam(unittest.TestCase):
         def can_end(conversation: Conversation) -> bool:
             return (
                 conversation.variables.get("result") == "done"
-                or len(conversation.messages) > 10
+                or len(conversation.messages) > 15
             )
 
         flow = PlannedTeam(
@@ -257,10 +257,10 @@ class TestPlannedTeam(unittest.TestCase):
         result = workflow.run("I want a new oven")
 
         self.assertEqual(result, "done", "Expected the workflow result to be 'done'")
-        self.assertIn(
-            "acceptable",
-            workflow.conversation.messages[-1]["content"],
-            "Expected result to be 'acceptable'",
+        self.assertEqual(
+            "done",
+            workflow.conversation.variables["result"],
+            "Expected 'result' variable to be 'done'",
         )
 
     def test_plan(self):

--- a/vanilla_aiagents/tests/test_update_strategy.py
+++ b/vanilla_aiagents/tests/test_update_strategy.py
@@ -1,55 +1,101 @@
 import unittest
 import os, logging, sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from vanilla_aiagents.conversation import Conversation, NoopUpdateStrategy, ReplaceLastMessageUpdateStrategy, AppendMessagesUpdateStrategy
+from vanilla_aiagents.conversation import (
+    Conversation,
+    NoopUpdateStrategy,
+    ReplaceLastMessageUpdateStrategy,
+    AppendMessagesUpdateStrategy,
+)
 from vanilla_aiagents.llm import AzureOpenAILLM
 from vanilla_aiagents.agent import Agent
 
 from dotenv import load_dotenv
+
 load_dotenv(override=True)
+
 
 class TestReadingStrategy(unittest.TestCase):
 
     def setUp(self):
-        self.llm = AzureOpenAILLM({
-            "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
-            "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
-            "api_key": os.getenv("AZURE_OPENAI_KEY"),
-            "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
-        })
-        
+        self.llm = AzureOpenAILLM(
+            {
+                "azure_deployment": os.getenv("AZURE_OPENAI_MODEL"),
+                "azure_endpoint": os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_key": os.getenv("AZURE_OPENAI_KEY"),
+                "api_version": os.getenv("AZURE_OPENAI_API_VERSION"),
+            }
+        )
+
         logging.basicConfig(level=logging.INFO)
         logging.getLogger("vanilla_aiagents.conversation").setLevel(logging.DEBUG)
 
     def test_append(self):
-        agent = Agent(id="test-agent", description="Test Agent", system_message="Simply say 'hello'", llm=self.llm, update_strategy=AppendMessagesUpdateStrategy())
-        
+        agent = Agent(
+            id="test-agent",
+            description="Test Agent",
+            system_message="Simply say 'hello'",
+            llm=self.llm,
+            update_strategy=AppendMessagesUpdateStrategy(),
+        )
+
         conversation = Conversation(messages=[], variables={})
         agent.ask(conversation)
-        
-        self.assertEqual(len(conversation.messages), 1, "Expected 1 message in the conversation")
-        
+
+        self.assertEqual(
+            len(conversation.messages), 1, "Expected 1 message in the conversation"
+        )
+
     def test_replace(self):
-        agent = Agent(id="test-agent", description="Test Agent", system_message="Simply say 'hello'", llm=self.llm, update_strategy=ReplaceLastMessageUpdateStrategy())
-        
+        agent = Agent(
+            id="test-agent",
+            description="Test Agent",
+            system_message="Simply say 'hello'",
+            llm=self.llm,
+            update_strategy=ReplaceLastMessageUpdateStrategy(),
+        )
+
         conversation = Conversation(messages=[], variables={})
-        conversation.messages.append({"role": "assistant", "content": "This will be replaced"})
+        conversation.messages.append(
+            {"role": "assistant", "content": "This will be replaced"}
+        )
         agent.ask(conversation)
-        
-        self.assertEqual(len(conversation.messages), 1, "Expected 1 message in the conversation")
-        self.assertNotIn("replaced", conversation.messages[0]["content"], "Expected message to be replaced")
-        
+
+        self.assertEqual(
+            len(conversation.messages), 1, "Expected 1 message in the conversation"
+        )
+        self.assertNotIn(
+            "replaced",
+            conversation.messages[0]["content"],
+            "Expected message to be replaced",
+        )
+
     def test_noop(self):
-        agent = Agent(id="test-agent", description="Test Agent", system_message="Simply say 'hello'", llm=self.llm, update_strategy=NoopUpdateStrategy())
-        
+        agent = Agent(
+            id="test-agent",
+            description="Test Agent",
+            system_message="Simply say 'hello'",
+            llm=self.llm,
+            update_strategy=NoopUpdateStrategy(),
+        )
+
         conversation = Conversation(messages=[], variables={})
-        conversation.messages.append({"role": "assistant", "content": "This will not be replaced"})
+        conversation.messages.append(
+            {"role": "assistant", "content": "This will not be replaced"}
+        )
         agent.ask(conversation)
-        
-        self.assertEqual(len(conversation.messages), 1, "Expected 1 message in the conversation")
-        self.assertNotIn("hello", conversation.messages[0]["content"], "Expected message NOT to be replaced")
-        
-if __name__ == '__main__':
+
+        self.assertEqual(
+            len(conversation.messages), 1, "Expected 1 message in the conversation"
+        )
+        self.assertNotIn(
+            "hello",
+            conversation.messages[0]["content"],
+            "Expected message NOT to be replaced",
+        )
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/vanilla_aiagents/vanilla_aiagents/planned_team.py
+++ b/vanilla_aiagents/vanilla_aiagents/planned_team.py
@@ -1,3 +1,4 @@
+import json
 from typing import Annotated, Callable
 
 from pydantic import BaseModel
@@ -33,10 +34,10 @@ class PlannedTeam(Askable):
         description: str,
         id: str,
         members: list[Askable],
-        stop_callback: Callable[[list[dict]], bool] = None,
         fork_conversation: bool = False,
         fork_strategy: ConversationReadingStrategy = None,
         include_tools_descriptions: bool = False,
+        repeat_until: Callable[[Conversation], bool] = None,
     ):
         """Initialize the PlannedTeam object.
 
@@ -53,10 +54,10 @@ class PlannedTeam(Askable):
         super().__init__(id, description)
         self.agents = members
         self.plan = None
-        self.stop_callback = stop_callback
         self.fork_conversation = fork_conversation
         self.fork_strategy = fork_strategy
         self.include_tools_descriptions = include_tools_descriptions
+        self.repeat_until = repeat_until
 
         self.current_agent = None
         self.agents_dict = {agent.id: agent for agent in members}
@@ -80,7 +81,7 @@ class PlannedTeam(Askable):
             self.plan = self._create_plan(conversation)
             logger.debug("[PlannedTeam %s] created plan: %s", self.id, self.plan)
 
-        execution_result = None
+        execution_result = "done"
         local_conversation = (
             conversation.fork() if self.fork_conversation else conversation
         )
@@ -120,16 +121,9 @@ class PlannedTeam(Askable):
                 execution_result = "agent-error"
                 break
 
-            if self.stop_callback is not None and self.stop_callback(
-                local_conversation.messages
-            ):
-                logger.debug(
-                    "[PlannedTeam %s] stop callback triggered, ending workflow.",
-                    self.id,
-                )
-                conversation.log.append(("info", "plannedteam/callback-stop", self.id))
-                execution_result = "callback-stop"
-                break
+        if self.repeat_until is not None:
+            while not self.repeat_until(local_conversation):
+                execution_result = self.ask(local_conversation, stream=stream)
 
         if stream:
             local_conversation.update(["end", self.id])
@@ -146,6 +140,7 @@ class PlannedTeam(Askable):
 You are a team orchestrator that must create a plan to solve the user inquiry by using the available agents.
 Your task is to create a plan that includes only the agents suitable to help, based on their descriptions.
 The plan must be a list of agent_id values, in the order they should be executed, along with the proper instructions for each agent.
+When FEEDBACK section has content, you must consider it to tailor the plan accordingly, since this means a previous plan was not successful to meet success criteria.
 The plan must be returned as JSON, with the following structure:
 
 {{
@@ -161,12 +156,13 @@ The plan must be returned as JSON, with the following structure:
 You MUST return the plan in the format specified above. DO NOT return anything else.
 
 # AVAILABLE AGENTS
-
 {agents}
 
 # INQUIRY
-
 {inquiry}
+
+# FEEDBACK
+{feedback}
 
 BE SURE TO READ AGAIN THE INSTUCTIONS ABOVE BEFORE PROCEEDING.
 """
@@ -175,11 +171,14 @@ BE SURE TO READ AGAIN THE INSTUCTIONS ABOVE BEFORE PROCEEDING.
         inquiry = conversation.messages[-1][
             "content"
         ]  # TODO pick the first user message
+        feedback = conversation.variables.get("__feedback", "")
 
         local_messages.append(
             {
                 "role": "system",
-                "content": system_prompt.format(agents=agents_info, inquiry=inquiry),
+                "content": system_prompt.format(
+                    agents=agents_info, inquiry=inquiry, feedback=feedback
+                ),
             }
         )
         local_messages.append(
@@ -193,6 +192,13 @@ BE SURE TO READ AGAIN THE INSTUCTIONS ABOVE BEFORE PROCEEDING.
 
         result, usage = self.llm.ask(messages=local_messages, response_format=TeamPlan)
         logger.debug("[PlannedTeam %s] result from Azure OpenAI: %s", self.id, result)
+        if self.llm.constraints.structured_output:
+            plan = result.parsed
+        else:
+            plan = result.content.replace("```json", "").replace("```", "")
+            plan = json.loads(plan)
+
+        output = TeamPlan.model_validate(plan)
 
         if usage is not None:
             # Update conversation metrics with response usage
@@ -200,7 +206,6 @@ BE SURE TO READ AGAIN THE INSTUCTIONS ABOVE BEFORE PROCEEDING.
             conversation.metrics.prompt_tokens += usage["prompt_tokens"]
             conversation.metrics.completion_tokens += usage["completion_tokens"]
 
-        output = TeamPlan.model_validate(result.parsed)
         return output.plan
 
     def _generate_agents_info(self):

--- a/vanilla_aiagents/vanilla_aiagents/planned_team.py
+++ b/vanilla_aiagents/vanilla_aiagents/planned_team.py
@@ -80,6 +80,8 @@ class PlannedTeam(Askable):
             conversation (Conversation): The conversation to use for the execution. If fork_conversation is set to True, a forked conversation will be used and the messages will be written to the main conversation only at the end (depending on the fork_strategy).
             stream (bool): Whether to stream the conversation updates.
         """
+        # TODO persist plan in a conversation variable and read it from there
+        # to support resuming plans
         if self.plan is None:
             self.plan = self._create_plan(conversation)
             logger.debug("[PlannedTeam %s] created plan: %s", self.id, self.plan)

--- a/vanilla_aiagents/vanilla_aiagents/planned_team.py
+++ b/vanilla_aiagents/vanilla_aiagents/planned_team.py
@@ -38,6 +38,7 @@ class PlannedTeam(Askable):
         fork_strategy: ConversationReadingStrategy = None,
         include_tools_descriptions: bool = False,
         repeat_until: Callable[[Conversation], bool] = None,
+        feedback_variable: str = "__feedback",
     ):
         """Initialize the PlannedTeam object.
 
@@ -50,6 +51,7 @@ class PlannedTeam(Askable):
             fork_conversation (bool): Whether to fork the conversation and avoid writing the messages to the main conversation.
             fork_strategy (ConversationReadingStrategy): The reading strategy to use to select the messages to report output back to the main conversation.
             include_tools_descriptions (bool): Whether to include the tools descriptions in the system prompt to help the orchestrator decide.
+            feedback_variable (str): The variable name to use to store the feedback from the previous plan execution.
         """
         super().__init__(id, description)
         self.agents = members
@@ -58,6 +60,7 @@ class PlannedTeam(Askable):
         self.fork_strategy = fork_strategy
         self.include_tools_descriptions = include_tools_descriptions
         self.repeat_until = repeat_until
+        self.feedback_variable = feedback_variable
 
         self.current_agent = None
         self.agents_dict = {agent.id: agent for agent in members}
@@ -171,7 +174,7 @@ BE SURE TO READ AGAIN THE INSTUCTIONS ABOVE BEFORE PROCEEDING.
         inquiry = conversation.messages[-1][
             "content"
         ]  # TODO pick the first user message
-        feedback = conversation.variables.get("__feedback", "")
+        feedback = conversation.variables.get(self.feedback_variable, "")
 
         local_messages.append(
             {


### PR DESCRIPTION
## Summary

This pull request includes various changes to improve the formatting, functionality, and structure of the codebase. The most important changes involve enhancing the `vanilla_aiagents` tests, updating the `.vscode/settings.json` file for better code formatting, and refining the `PlannedTeam` workflow to support reiterating a plan after feedback evaluation.

### Enhancements to `vanilla_aiagents` tests:

* [`vanilla_aiagents/tests/test_llm.py`](diffhunk://#diff-a8918e24f3c6ee2be6df4d702355080c338ecab1426c8e16fe3e361c656ea469L4-R29): Added `LLMConstraints` and a new test for constraints to ensure the constraints are working correctly. Improved formatting and readability by adding line breaks and reformatting the code. [[1]](diffhunk://#diff-a8918e24f3c6ee2be6df4d702355080c338ecab1426c8e16fe3e361c656ea469L4-R29) [[2]](diffhunk://#diff-a8918e24f3c6ee2be6df4d702355080c338ecab1426c8e16fe3e361c656ea469L33-R174)
* [`vanilla_aiagents/tests/test_planned_team.py`](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L5-R40): Added imports for `Conversation` and improved formatting and readability by adding line breaks and reformatting the code. Introduced new tests for `feedback` and `plan` to enhance the testing coverage. [[1]](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L5-R40) [[2]](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L50-R65) [[3]](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L62-R271) [[4]](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L141-R296) [[5]](diffhunk://#diff-be98ae6859998ee0db5b4e97011affc6b0c5761596bd4ca91097d03dbe0c9c22L153-R324)

### Code formatting improvements:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2-R10): Configured the default formatter to `ms-python.black-formatter` and enabled `formatOnSave` for Python files. Added settings to organize and remove unused imports on save.

### Refinements to `PlannedTeam` workflow:

* [`notebooks/planned_team.ipynb`](diffhunk://#diff-b7212ddc5361c9d36bf54d444265d9111e9bfbb041167862b47f9d20d93f7759L120): Removed the `stop_callback` parameter from the `PlannedTeam` initialization to streamline the workflow setup.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[] No
```
`PlannedTeam` no longer accepts a `stop_callback` param - which was not very applicable. Instead a new `repeat_until` callback allows to reiterate and generate new plans enabling feedback-loop graphs.